### PR TITLE
nvidia-driver installation failure

### DIFF
--- a/scripts/initialization_actions.sh
+++ b/scripts/initialization_actions.sh
@@ -20,28 +20,22 @@ apt-get install -y pciutils
 # Add non-free Debian 9 Stretch packages.
 # See https://www.debian.org/distrib/packages#note
 for type in deb deb-src; do
-  for distro in stretch stretch-backports; do
+  for distro in stretch; do
     for component in contrib non-free; do
       echo "${type} http://deb.debian.org/debian/ ${distro} ${component}" \
           >> /etc/apt/sources.list.d/non-free.list
     done
   done
 done
+apt update
 
 # Install proprietary NVIDIA Drivers and CUDA
 # See https://wiki.debian.org/NvidiaGraphicsDrivers
 export DEBIAN_FRONTEND=noninteractive
-#apt-get install -y "linux-headers-$(uname -r)"
 apt-get install -y linux-headers-$(uname -r|sed 's/[^-]*-[^-]*-//')
-apt update
 # Without --no-install-recommends this takes a very long time.
-#apt install -y -t stretch-backports --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common
-apt install -y -t stretch --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common
-apt install -y -t stretch --no-install-recommends nvidia-driver nvidia-smi
-
-apt-get update
-# apt-get update && apt-get upgrade -y
-apt install -y nvidia-driver nvidia-smi
+apt install -y -t stretch --no-install-recommends \
+  nvidia-cuda-toolkit nvidia-kernel-common nvidia-driver nvidia-smi
 
 # Create a system wide NVBLAS config
 # See http://docs.nvidia.com/cuda/nvblas/

--- a/scripts/initialization_actions.sh
+++ b/scripts/initialization_actions.sh
@@ -36,6 +36,8 @@ apt-get install -y "linux-headers-$(uname -r)"
 # Without --no-install-recommends this takes a very long time.
 apt-get install -y -t stretch-backports --no-install-recommends \
   nvidia-cuda-toolkit nvidia-kernel-common nvidia-driver nvidia-smi
+apt-get update && apt-get upgrade -y
+apt-get install -y nvidia-driver nvidia-smi
 
 # Create a system wide NVBLAS config
 # See http://docs.nvidia.com/cuda/nvblas/

--- a/scripts/initialization_actions.sh
+++ b/scripts/initialization_actions.sh
@@ -32,7 +32,7 @@ done
 # See https://wiki.debian.org/NvidiaGraphicsDrivers
 export DEBIAN_FRONTEND=noninteractive
 #apt-get install -y "linux-headers-$(uname -r)"
-apt-get install linux-headers-$(uname -r|sed 's/[^-]*-[^-]*-//')
+apt-get install -y linux-headers-$(uname -r|sed 's/[^-]*-[^-]*-//')
 apt update
 # Without --no-install-recommends this takes a very long time.
 apt install -y -t stretch-backports --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common

--- a/scripts/initialization_actions.sh
+++ b/scripts/initialization_actions.sh
@@ -31,14 +31,13 @@ done
 # Install proprietary NVIDIA Drivers and CUDA
 # See https://wiki.debian.org/NvidiaGraphicsDrivers
 export DEBIAN_FRONTEND=noninteractive
-apt-get install -y "linux-headers-$(uname -r)"
+#apt-get install -y "linux-headers-$(uname -r)"
+apt-get install linux-headers-$(uname -r|sed 's/[^-]*-[^-]*-//')
+apt update
 # Without --no-install-recommends this takes a very long time.
-apt-get install -y -t stretch-backports --no-install-recommends \
-  nvidia-cuda-toolkit nvidia-kernel-common
-##nvidia-driver nvidia-smi
+apt install -y -t stretch-backports --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common
+apt install -y -t stretch-backports --no-install-recommends nvidia-driver nvidia-smi
 
-# See https://wiki.debian.org/NvidiaGraphicsDrivers#stretch
-echo "deb http://httpredir.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list
 apt-get update
 # apt-get update && apt-get upgrade -y
 apt install -y nvidia-driver nvidia-smi

--- a/scripts/initialization_actions.sh
+++ b/scripts/initialization_actions.sh
@@ -27,7 +27,6 @@ for type in deb deb-src; do
     done
   done
 done
-apt-get update
 
 # Install proprietary NVIDIA Drivers and CUDA
 # See https://wiki.debian.org/NvidiaGraphicsDrivers
@@ -35,9 +34,14 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y "linux-headers-$(uname -r)"
 # Without --no-install-recommends this takes a very long time.
 apt-get install -y -t stretch-backports --no-install-recommends \
-  nvidia-cuda-toolkit nvidia-kernel-common nvidia-driver nvidia-smi
-apt-get update && apt-get upgrade -y
-apt-get install -y nvidia-driver nvidia-smi
+  nvidia-cuda-toolkit nvidia-kernel-common
+##nvidia-driver nvidia-smi
+
+# See https://wiki.debian.org/NvidiaGraphicsDrivers#stretch
+echo "deb http://httpredir.debian.org/debian stretch-backports main contrib non-free" >> /etc/apt/sources.list
+apt-get update
+# apt-get update && apt-get upgrade -y
+apt install -y nvidia-driver nvidia-smi
 
 # Create a system wide NVBLAS config
 # See http://docs.nvidia.com/cuda/nvblas/

--- a/scripts/initialization_actions.sh
+++ b/scripts/initialization_actions.sh
@@ -35,8 +35,9 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get install -y linux-headers-$(uname -r|sed 's/[^-]*-[^-]*-//')
 apt update
 # Without --no-install-recommends this takes a very long time.
-apt install -y -t stretch-backports --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common
-apt install -y -t stretch-backports --no-install-recommends nvidia-driver nvidia-smi
+#apt install -y -t stretch-backports --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common
+apt install -y -t stretch --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common
+apt install -y -t stretch --no-install-recommends nvidia-driver nvidia-smi
 
 apt-get update
 # apt-get update && apt-get upgrade -y


### PR DESCRIPTION
Setting up linux-headers-4.9.0-8-amd64 (4.9.144-3.1) ...
+ apt-get install -y -t stretch-backports --no-install-recommends nvidia-cuda-toolkit nvidia-kernel-common nvidia-driver nvidia-smi
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 nvidia-driver : Depends: nvidia-driver-libs (= 390.87-8~deb9u1) but it is not going to be installed or
                          nvidia-driver-libs-nonglvnd (= 390.87-8~deb9u1) but it is not going to be installed
                 Depends: nvidia-driver-bin (= 390.87-8~deb9u1) but it is not going to be installed
                 Depends: xserver-xorg-video-nvidia (= 390.87-8~deb9u1) but it is not going to be installed
                 Depends: nvidia-vdpau-driver (= 390.87-8~deb9u1) but 410.104-1~bpo9+1 is to be installed
                 Depends: nvidia-alternative (= 390.87-8~deb9u1) but 410.104-1~bpo9+1 is to be installed
                 Depends: nvidia-kernel-dkms (= 390.87-8~deb9u1) but it is not going to be installed or
                          nvidia-kernel-390.87
 nvidia-smi : Depends: nvidia-alternative (= 390.87-8~deb9u1) but 410.104-1~bpo9+1 is to be installed
              Depends: libnvidia-ml1 (= 390.87-8~deb9u1) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
[info] initialization_actions.sh done
